### PR TITLE
MoS2 fd mode and Ru2Cl6 higher pw cutoff

### DIFF
--- a/benchmarks/MoS2-benchmark.py
+++ b/benchmarks/MoS2-benchmark.py
@@ -1,7 +1,7 @@
 from math import pi
 import numpy as np
 from ase.build import mx2
-from gpaw import GPAW, PW, Davidson
+from gpaw import GPAW, Davidson
 
 # Create tube of MoS2:
 atoms = mx2('MoS2', size=(3, 2, 1))
@@ -18,16 +18,14 @@ atoms.positions = p2
 atoms.cell = [atoms.cell[0, 0], 0, 0]
 
 # setup calculator
-ecut = 800
 kpoints = (4, 1, 1)
 atoms.center(vacuum=6, axis=[1, 2])
 atoms.pbc = True
 tag = 'MoS2-benchmark'
-atoms.calc = GPAW(mode=PW(ecut),
+atoms.calc = GPAW(gpts=(48, 168, 168),
                   eigensolver=Davidson(2),
                   xc='PBE',
                   txt=tag + '.txt',
                   kpts={'size': kpoints},
-                  nbands='120%',
-                  parallel={'augment_grids': True})
+                  nbands='120%')
 forces = atoms.get_forces()

--- a/benchmarks/Ru2Cl6-benchmark.py
+++ b/benchmarks/Ru2Cl6-benchmark.py
@@ -35,7 +35,7 @@ def get_mm(atoms, state):
 
 def pbeU(tag=None):
     U = 4.0
-    ecut = 800
+    ecut = 1200
     kdens = 12
     width = 0.01
     atoms = read('Ru2Cl6-input.json')


### PR DESCRIPTION
switch to fd mode and use a higher plane-wave cutoff energy for Ru2Cl6